### PR TITLE
feat(auth): migrate CountryService to central token exchange

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <ServiceDefaultsVersion Condition="'$(ServiceDefaultsVersion)' == ''">1.0.89-alpha</ServiceDefaultsVersion>
     <SharedLibraryVersion Condition="'$(SharedLibraryVersion)' == ''">1.0.*-alpha*</SharedLibraryVersion>
   </PropertyGroup>
 

--- a/Maliev.CountryService.Api/Dockerfile
+++ b/Maliev.CountryService.Api/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Build.props", "."]
 COPY ["Maliev.CountryService.Api/Maliev.CountryService.Api.csproj", "Maliev.CountryService.Api/"]
 COPY ["Maliev.CountryService.Application/Maliev.CountryService.Application.csproj", "Maliev.CountryService.Application/"]
 COPY ["Maliev.CountryService.Domain/Maliev.CountryService.Domain.csproj", "Maliev.CountryService.Domain/"]
@@ -19,17 +20,18 @@ COPY ["Maliev.CountryService.Infrastructure/Maliev.CountryService.Infrastructure
 COPY ["nuget.config", "."]
 RUN --mount=type=secret,id=nuget_username \
     --mount=type=secret,id=nuget_password \
+    GITHUB_ACTIONS=true \
     NUGET_USERNAME=$(cat /run/secrets/nuget_username) \
     NUGET_PASSWORD=$(cat /run/secrets/nuget_password) \
     dotnet restore "./Maliev.CountryService.Api/Maliev.CountryService.Api.csproj"
 COPY . .
 WORKDIR "/src/Maliev.CountryService.Api"
-RUN dotnet build "./Maliev.CountryService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN GITHUB_ACTIONS=true dotnet build "./Maliev.CountryService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./Maliev.CountryService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN GITHUB_ACTIONS=true dotnet publish "./Maliev.CountryService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final

--- a/Maliev.CountryService.Api/Maliev.CountryService.Api.csproj
+++ b/Maliev.CountryService.Api/Maliev.CountryService.Api.csproj
@@ -24,7 +24,7 @@
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ProjectReference Include="..\Maliev.CountryService.Application\Maliev.CountryService.Application.csproj" />
     <ProjectReference Include="..\Maliev.CountryService.Infrastructure\Maliev.CountryService.Infrastructure.csproj" />
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Maliev.CountryService.Api/Program.cs
+++ b/Maliev.CountryService.Api/Program.cs
@@ -100,7 +100,8 @@ try
     // Register hosted services
     builder.Services.AddHostedService<CacheWarmingService>();
     builder.Services.AddHostedService<BulkImportWorkerService>();
-    builder.AddIAMServiceClient("country");
+    builder.AddAuthServiceTokenExchange("CountryService");
+    builder.AddAuthServiceIAMClient();
     builder.Services.AddIAMRegistration<Maliev.CountryService.Api.Services.CountryIAMRegistrationService>("country");
 
     var app = builder.Build();

--- a/Maliev.CountryService.Application/Maliev.CountryService.Application.csproj
+++ b/Maliev.CountryService.Application/Maliev.CountryService.Application.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.CountryService.Infrastructure/Maliev.CountryService.Infrastructure.csproj
+++ b/Maliev.CountryService.Infrastructure/Maliev.CountryService.Infrastructure.csproj
@@ -29,7 +29,7 @@
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ProjectReference Include="..\Maliev.CountryService.Application\Maliev.CountryService.Application.csproj" />
     <ProjectReference Include="..\Maliev.CountryService.Domain\Maliev.CountryService.Domain.csproj" />
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.CountryService.Tests/Maliev.CountryService.Tests.csproj
+++ b/Maliev.CountryService.Tests/Maliev.CountryService.Tests.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.CountryService.Tests/Testing/BaseIntegrationTestFactory.cs
+++ b/Maliev.CountryService.Tests/Testing/BaseIntegrationTestFactory.cs
@@ -62,7 +62,7 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
         {
             if (!_containersStarted)
             {
-                _postgresContainer = 
+                _postgresContainer =
 #pragma warning disable CS0618
         new PostgreSqlBuilder().WithImage("postgres:18-alpine")
                     .Build();
@@ -178,6 +178,14 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
                 ["ConnectionStrings:rabbitmq"] = _rabbitmqContainer!.GetConnectionString(),
                 ["CORS:AllowedOrigins:0"] = "http://localhost:3000",
                 ["CORS_ALLOWED_ORIGINS"] = "http://localhost:3000",
+                ["ServiceAuthentication:ClientId"] = "service-country-service",
+                ["ServiceAuthentication:ClientSecret"] = "country-test-secret-with-at-least-32-bytes",
+                ["Services:AuthService:BaseUrl"] = "https://auth.test",
+                ["Services:IAMService:BaseUrl"] = "https://iam.test",
+                ["Jwt:PublicKey"] = Convert.ToBase64String(
+                    System.Text.Encoding.UTF8.GetBytes(_testRsa.ExportSubjectPublicKeyInfoPem())),
+                ["Jwt:Issuer"] = "https://test-issuer.maliev.com",
+                ["Jwt:Audience"] = "https://test-audience.maliev.com",
                 ["IAM:RegistrationDelaySeconds"] = "0",
                 ["RateLimiting:PermitLimit"] = "10000",
                 ["RateLimiting:WindowMinutes"] = "1",

--- a/Maliev.CountryService.Tests/Testing/BaseIntegrationTestFactory.cs
+++ b/Maliev.CountryService.Tests/Testing/BaseIntegrationTestFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -62,9 +63,8 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
         {
             if (!_containersStarted)
             {
-                _postgresContainer =
 #pragma warning disable CS0618
-        new PostgreSqlBuilder().WithImage("postgres:18-alpine")
+                _postgresContainer = new PostgreSqlBuilder().WithImage("postgres:18-alpine")
                     .Build();
 
                 _redisContainer = new RedisBuilder("redis:7.4-alpine")
@@ -183,7 +183,7 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
                 ["Services:AuthService:BaseUrl"] = "https://auth.test",
                 ["Services:IAMService:BaseUrl"] = "https://iam.test",
                 ["Jwt:PublicKey"] = Convert.ToBase64String(
-                    System.Text.Encoding.UTF8.GetBytes(_testRsa.ExportSubjectPublicKeyInfoPem())),
+                    Encoding.UTF8.GetBytes(_testRsa.ExportSubjectPublicKeyInfoPem())),
                 ["Jwt:Issuer"] = "https://test-issuer.maliev.com",
                 ["Jwt:Audience"] = "https://test-audience.maliev.com",
                 ["IAM:RegistrationDelaySeconds"] = "0",

--- a/Maliev.CountryService.Tests/Unit/ServiceAuthenticationWiringTests.cs
+++ b/Maliev.CountryService.Tests/Unit/ServiceAuthenticationWiringTests.cs
@@ -1,0 +1,335 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Asp.Versioning;
+using Maliev.Aspire.ServiceDefaults.Authorization;
+using Maliev.Aspire.ServiceDefaults.IAM;
+using Maliev.CountryService.Api.Authorization;
+using Maliev.CountryService.Api.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+
+namespace Maliev.CountryService.Tests.Unit;
+
+/// <summary>
+/// Tests CountryService's outbound workload authentication boundary.
+/// </summary>
+public sealed class ServiceAuthenticationWiringTests
+{
+    private const string ExpectedToken = "centrally-issued-country-token";
+
+    /// <summary>
+    /// CountryService startup should opt into AuthService exchange and the central IAM client only.
+    /// </summary>
+    [Fact]
+    public void Program_RegistersCountryExchangeWithoutLegacySigner()
+    {
+        var source = ReadRepositoryFile("Maliev.CountryService.Api", "Program.cs");
+
+        Assert.Contains("builder.AddAuthServiceTokenExchange(\"CountryService\");", source, StringComparison.Ordinal);
+        Assert.Contains("builder.AddAuthServiceIAMClient();", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddIAMServiceClient", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The process identity should be exact and no local-signing services should resolve.
+    /// </summary>
+    [Fact]
+    public void AuthServiceIamClient_RegistersExactIdentityWithoutLegacySigningServices()
+    {
+        var builder = CreateConfiguredBuilder();
+
+        builder.AddAuthServiceTokenExchange("CountryService");
+        builder.AddAuthServiceIAMClient();
+
+        using var provider = builder.Services.BuildServiceProvider();
+        var identity = provider.GetRequiredService<ServiceProcessIdentity>();
+
+        Assert.Equal("CountryService", identity.ServiceName);
+        Assert.Single(provider.GetServices<IIamServiceClient>());
+        Assert.Null(provider.GetService<IServiceAccountTokenProvider>());
+        Assert.Null(provider.GetService<ServiceAccountAuthenticationHandler>());
+    }
+
+    /// <summary>
+    /// IAM permission checks should use the bearer token supplied by AuthService exchange.
+    /// </summary>
+    [Fact]
+    public async Task IamPermissionCheck_UsesAuthServiceExchangedBearerTokenOnExactRoute()
+    {
+        var builder = CreateConfiguredBuilder();
+        var capture = new AuthorizationCaptureHandler();
+        builder.Services.AddSingleton<IHttpMessageHandlerBuilderFilter>(
+            new CapturingPrimaryHandlerFilter(capture));
+
+        builder.AddAuthServiceTokenExchange("CountryService");
+        builder.Services.AddSingleton<IAuthServiceTokenProvider>(new StubTokenProvider());
+        builder.AddAuthServiceIAMClient();
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var iamClient = scope.ServiceProvider.GetRequiredService<IIamServiceClient>();
+
+        var allowed = await iamClient.CheckPermissionAsync(
+            $"country-test-{Guid.NewGuid():N}",
+            CountryPermissions.CountriesRead,
+            cancellationToken: CancellationToken.None);
+
+        Assert.True(allowed);
+        Assert.Equal(new AuthenticationHeaderValue("Bearer", ExpectedToken), capture.Authorization);
+        Assert.Equal(HttpMethod.Post, capture.Method);
+        Assert.Equal(new Uri("https://iam.test/iam/v1/auth/check-permission"), capture.RequestUri);
+    }
+
+    /// <summary>
+    /// Missing or malformed workload credentials should fail options validation.
+    /// </summary>
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("service-country-service", "short")]
+    public async Task AuthServiceExchange_InvalidCredentials_FailsClosedAtHostStartup(
+        string? clientId,
+        string? clientSecret)
+    {
+        var builder = CreateConfiguredBuilder(clientId, clientSecret);
+        builder.AddAuthServiceTokenExchange("CountryService");
+
+        using var host = builder.Build();
+
+        await Assert.ThrowsAsync<OptionsValidationException>(() => host.StartAsync());
+    }
+
+    /// <summary>
+    /// CI should consume the exact published ServiceDefaults version containing central exchange support.
+    /// </summary>
+    [Fact]
+    public void ServiceDefaultsDependency_PinsPublishedCentralExchangeVersion()
+    {
+        var source = ReadRepositoryFile("Directory.Build.props");
+
+        Assert.Contains(
+            "<ServiceDefaultsVersion Condition=\"'$(ServiceDefaultsVersion)' == ''\">1.0.89-alpha</ServiceDefaultsVersion>",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "<ServiceDefaultsVersion Condition=\"'$(ServiceDefaultsVersion)' == ''\">1.0.*",
+            source,
+            StringComparison.Ordinal);
+
+        foreach (var project in new[]
+                 {
+                     "Maliev.CountryService.Api/Maliev.CountryService.Api.csproj",
+                     "Maliev.CountryService.Application/Maliev.CountryService.Application.csproj",
+                     "Maliev.CountryService.Infrastructure/Maliev.CountryService.Infrastructure.csproj",
+                     "Maliev.CountryService.Tests/Maliev.CountryService.Tests.csproj"
+                 })
+        {
+            var projectSource = ReadRepositoryFile(project.Split('/'));
+            Assert.Contains(
+                "<PackageReference Include=\"Maliev.Aspire.ServiceDefaults\" Version=\"$(ServiceDefaultsVersion)\" />",
+                projectSource,
+                StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The Docker restore layer must include the shared version property before restoring package-mode projects.
+    /// </summary>
+    [Fact]
+    public void Dockerfile_CopiesSharedVersionPropertiesBeforePackageRestore()
+    {
+        var source = ReadRepositoryFile("Maliev.CountryService.Api", "Dockerfile");
+        var propertiesCopy = source.IndexOf(
+            "COPY [\"Directory.Build.props\", \".\"]",
+            StringComparison.Ordinal);
+        var restore = source.IndexOf(
+            "dotnet restore \"./Maliev.CountryService.Api/Maliev.CountryService.Api.csproj\"",
+            StringComparison.Ordinal);
+
+        Assert.True(propertiesCopy >= 0, "Dockerfile must copy Directory.Build.props into the restore layer.");
+        Assert.True(restore > propertiesCopy, "Directory.Build.props must be available before dotnet restore.");
+    }
+
+    /// <summary>
+    /// Country routes and permission policies are part of the service contract and must remain unchanged.
+    /// </summary>
+    [Fact]
+    public void CountryEndpoints_RetainVersionedRoutesAndPermissionPolicies()
+    {
+        AssertControllerRoute<CountriesController>("country/v{version:apiVersion}/countries");
+        AssertEndpoint<CountriesController>(nameof(CountriesController.GetById), "{id:guid}", "GET", CountryPermissions.CountriesRead);
+        AssertEndpoint<CountriesController>(nameof(CountriesController.GetByIso2), "iso2/{iso2}", "GET", CountryPermissions.CountriesRead);
+        AssertEndpoint<CountriesController>(nameof(CountriesController.GetByIso3), "iso3/{iso3}", "GET", CountryPermissions.CountriesRead);
+        AssertEndpoint<CountriesController>(nameof(CountriesController.List), null, "GET", CountryPermissions.CountriesList);
+        AssertEndpoint<CountriesController>(nameof(CountriesController.Search), "search", "GET", CountryPermissions.CountriesSearch);
+
+        AssertControllerRoute<AdminCountriesController>("country/v{version:apiVersion}/admin/countries");
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.Create), null, "POST", CountryPermissions.CountriesCreate);
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.Update), "{id:guid}", "PUT", CountryPermissions.CountriesUpdate);
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.Patch), "{id:guid}", "PATCH", CountryPermissions.CountriesUpdate);
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.SoftDelete), "{id:guid}", "DELETE", CountryPermissions.CountriesDelete);
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.HardDelete), "{id:guid}/hard-delete", "DELETE", CountryPermissions.CountriesHardDelete);
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.Restore), "{id:guid}/restore", "POST", CountryPermissions.CountriesRestore);
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.RebuildCache), "rebuild-cache", "POST", CountryPermissions.SystemRebuildCache);
+        AssertEndpoint<AdminCountriesController>(nameof(AdminCountriesController.ExportAll), "export", "GET", CountryPermissions.SystemExport);
+
+        AssertControllerRoute<BulkImportController>("country/v{version:apiVersion}/admin/bulk-import");
+        AssertEndpoint<BulkImportController>(nameof(BulkImportController.SubmitBulkImport), null, "POST", CountryPermissions.ImportUpload);
+        AssertEndpoint<BulkImportController>(nameof(BulkImportController.GetJobStatus), "{jobId:guid}", "GET", CountryPermissions.ImportStatus);
+        AssertEndpoint<BulkImportController>(nameof(BulkImportController.ProcessJob), "{jobId:guid}/process", "POST", CountryPermissions.ImportExecute);
+    }
+
+    /// <summary>
+    /// Opting the IAM client into exchange must not attach bearer authentication to unrelated clients.
+    /// </summary>
+    [Fact]
+    public async Task AuthServiceExchange_DoesNotContaminateUnrelatedHttpClients()
+    {
+        var builder = CreateConfiguredBuilder();
+        var capture = new AuthorizationCaptureHandler();
+        var tokenProvider = new CountingTokenProvider();
+        builder.Services.AddSingleton<IHttpMessageHandlerBuilderFilter>(
+            new CapturingPrimaryHandlerFilter(capture));
+        builder.Services.AddHttpClient("CountryUnrelated", client =>
+            client.BaseAddress = new Uri("https://unrelated.test"));
+
+        builder.AddAuthServiceTokenExchange("CountryService");
+        builder.Services.AddSingleton<IAuthServiceTokenProvider>(tokenProvider);
+        builder.AddAuthServiceIAMClient();
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("CountryUnrelated");
+        using var response = await client.GetAsync("/probe", CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(capture.Authorization);
+        Assert.Equal(0, tokenProvider.CallCount);
+        Assert.Equal(new Uri("https://unrelated.test/probe"), capture.RequestUri);
+    }
+
+    private static HostApplicationBuilder CreateConfiguredBuilder(
+        string? clientId = "service-country-service",
+        string? clientSecret = "country-test-secret-with-at-least-32-bytes")
+    {
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = "Testing"
+        });
+
+        using var rsa = RSA.Create(2048);
+        builder.Configuration["ServiceAuthentication:ClientId"] = clientId;
+        builder.Configuration["ServiceAuthentication:ClientSecret"] = clientSecret;
+        builder.Configuration["Services:AuthService:BaseUrl"] = "https://auth.test";
+        builder.Configuration["Services:IAMService:BaseUrl"] = "https://iam.test";
+        builder.Configuration["Jwt:PublicKey"] = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes(rsa.ExportSubjectPublicKeyInfoPem()));
+        builder.Configuration["Jwt:Issuer"] = "https://api.maliev.com";
+        builder.Configuration["Jwt:Audience"] = "https://api.maliev.com";
+
+        return builder;
+    }
+
+    private static void AssertControllerRoute<TController>(string expectedTemplate)
+    {
+        var controller = typeof(TController);
+        Assert.NotNull(controller.GetCustomAttribute<ApiVersionAttribute>());
+        Assert.Equal(expectedTemplate, controller.GetCustomAttribute<RouteAttribute>()?.Template);
+    }
+
+    private static void AssertEndpoint<TController>(
+        string methodName,
+        string? expectedTemplate,
+        string expectedVerb,
+        string expectedPermission)
+    {
+        var method = typeof(TController).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var route = method.GetCustomAttributes<HttpMethodAttribute>().Single();
+        Assert.Equal(expectedTemplate, route.Template);
+        Assert.Contains(expectedVerb, route.HttpMethods);
+        Assert.Equal(expectedPermission, method.GetCustomAttribute<RequirePermissionAttribute>()?.Permission);
+    }
+
+    private static string ReadRepositoryFile(params string[] segments)
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            Path.Combine(segments)));
+
+        Assert.True(File.Exists(path), $"Could not find source file: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private sealed class StubTokenProvider : IAuthServiceTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(ExpectedToken);
+    }
+
+    private sealed class CountingTokenProvider : IAuthServiceTokenProvider
+    {
+        public int CallCount { get; private set; }
+
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(ExpectedToken);
+        }
+    }
+
+    private sealed class AuthorizationCaptureHandler : HttpMessageHandler
+    {
+        public AuthenticationHeaderValue? Authorization { get; private set; }
+
+        public HttpMethod? Method { get; private set; }
+
+        public Uri? RequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Authorization = request.Headers.Authorization;
+            Method = request.Method;
+            RequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"allowed\":true}", Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class CapturingPrimaryHandlerFilter(HttpMessageHandler primaryHandler)
+        : IHttpMessageHandlerBuilderFilter
+    {
+        public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next) => builder =>
+        {
+            next(builder);
+            for (var index = builder.AdditionalHandlers.Count - 1; index >= 0; index--)
+            {
+                if (builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ServiceDiscovery",
+                        StringComparison.Ordinal) == true ||
+                    builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ResolvingHttpDelegatingHandler",
+                        StringComparison.Ordinal) == true)
+                {
+                    builder.AdditionalHandlers.RemoveAt(index);
+                }
+            }
+
+            builder.PrimaryHandler = primaryHandler;
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- replace CountryService's executable legacy IAM client with AuthService token exchange plus the central IAM client
- pin `Maliev.Aspire.ServiceDefaults` to `1.0.89-alpha` for package-mode builds
- make the production Docker restore layer copy `Directory.Build.props` first and use package mode for restore/build/publish
- add regressions for exact process identity, fail-closed startup validation, exact bearer `POST /iam/v1/auth/check-permission`, legacy signer absence, unrelated HTTP-client isolation, endpoint metadata preservation, and Docker ordering

## Validation
- focused auth boundary: 9/9
- non-integration: 169/169
- integration: 90/90
- full Release suite: 259/259
- normal Release build: 0 warnings, 0 errors
- package-mode Release build with published ServiceDefaults: 0 warnings, 0 errors
- scoped format verification: clean
- production Docker build: success (`sha256:068b83355b0852c2675d815132133b4d464b46cb3f33e412eae9503e70a22ae3`)
- independent security/correctness review: approved; POST assertion follow-up applied

Tracking: MALIEV-Co-Ltd/maliev-ops#91

No application was enabled, synced, merged, or deployed by this change.