### PR TITLE
ci: configure Dependabot update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      nuget-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "docker"
+    directory: "/Maliev.CountryService.Api"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      docker-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds a weekly Dependabot policy limited to ecosystems present on the default branch. Minor and patch updates are grouped per ecosystem; major updates remain separate. NuGet is capped at 10 open PRs, while Docker and GitHub Actions are capped at 5. No auto-merge or runtime behavior is introduced.

Validation:
- YAML parsed successfully
- ecosystem directories and Dockerfile paths verified
- limits, weekly schedule, and update-type groups asserted
- git diff --check passed